### PR TITLE
#36437 Increase default limits for large carts / orders

### DIFF
--- a/event/package.json
+++ b/event/package.json
@@ -13,7 +13,7 @@
     "build": "rimraf ./build && tsc",
     "lint": "eslint . --ext .ts",
     "prettier": "prettier --write '**/*.{js,ts}'",
-    "test": "jest --config jest.config.cjs --coverage",
+    "test": "jest --config jest.config.cjs --coverage --testTimeout=30000",
     "test:watch": "jest --watch",
     "connector:post-deploy": "node build/connector/post-deploy.js",
     "connector:pre-undeploy": "node build/connector/pre-undeploy.js"

--- a/event/src/avalara/utils/avatax.config.ts
+++ b/event/src/avalara/utils/avatax.config.ts
@@ -7,7 +7,7 @@ export function avaTaxConfig(env: string, enabled?: boolean, level?: string) {
     appVersion: 'a0o5a000008TO2qAAG',
     machineName: 'v1',
     environment: env,
-    timeout: 5000,
+    timeout: 10000,
     customHttpAgent: new http.Agent({ keepAlive: true }),
     logOptions: {
       logEnabled: !!enabled, // toggle logging on or off, by default its off.

--- a/event/src/client/data.client.ts
+++ b/event/src/client/data.client.ts
@@ -37,7 +37,7 @@ export const getBulkCategoryTaxCode = async (cats: Array<string>) => {
   const taxCodes = (
     await createApiRoot()
       .categories()
-      .get({ queryArgs: { where: `id in (${cs})` } })
+      .get({ queryArgs: { where: `id in (${cs})`, limit: 500 } })
       .execute()
   )?.body?.results.map((x) => ({
     id: x.id,
@@ -57,7 +57,7 @@ export const getBulkProductCategories = async (
     await createApiRoot()
       .productProjections()
       .search()
-      .get({ queryArgs: { filter: ps } })
+      .get({ queryArgs: { filter: ps, limit: 500 } })
       .execute()
   )?.body?.results;
   const result: any = keys.map((x) => ({

--- a/event/src/index.ts
+++ b/event/src/index.ts
@@ -21,7 +21,7 @@ const app: Express = express();
 app.disable('x-powered-by');
 
 // Define configurations
-app.use(bodyParser.json());
+app.use(bodyParser.json({ limit: '16mb' }));
 app.use(bodyParser.urlencoded({ extended: true }));
 
 // Define routes

--- a/event/tests/client.spec.ts
+++ b/event/tests/client.spec.ts
@@ -82,7 +82,7 @@ describe('test coco api client', () => {
     expect(apiRoot.productProjections).toBeCalledTimes(1);
     expect(apiRoot.search).toBeCalledTimes(1);
     expect(apiRoot.get).toBeCalledWith({
-      queryArgs: { filter: `variants.sku:"sku123","sku456"` },
+      queryArgs: { filter: `variants.sku:"sku123","sku456"`, limit: 500 },
     });
     expect(apiRoot.execute).toBeCalledTimes(1);
 
@@ -100,7 +100,7 @@ describe('test coco api client', () => {
     const data = await getBulkCategoryTaxCode(['123', '456']);
     expect(apiRoot.categories).toBeCalledTimes(1);
     expect(apiRoot.get).toBeCalledWith({
-      queryArgs: { where: `id in ("123", "456")` },
+      queryArgs: { where: `id in ("123", "456")`, limit: 500 },
     });
     expect(apiRoot.execute).toBeCalledTimes(1);
 

--- a/event/tests/event.spec.ts
+++ b/event/tests/event.spec.ts
@@ -190,7 +190,7 @@ describe('test event controller', () => {
           logRequestAndResponseInfo: true,
         },
         machineName: 'v1',
-        timeout: 5000,
+        timeout: 10000,
       });
     }
   );

--- a/service/package.json
+++ b/service/package.json
@@ -13,7 +13,7 @@
     "build": "rimraf ./build && tsc",
     "lint": "eslint . --ext .ts",
     "prettier": "prettier --write '**/*.{js,ts}'",
-    "test": "jest --config jest.config.cjs --coverage",
+    "test": "jest --config jest.config.cjs --coverage --testTimeout=30000",
     "test:watch": "jest --watch",
     "connector:post-deploy": "node build/connector/post-deploy.js",
     "connector:pre-undeploy": "node build/connector/pre-undeploy.js"
@@ -39,10 +39,10 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
-    "@commercetools-backend/express": "^22.15.0",
-    "@commercetools-backend/loggers": "^22.23.3",
-    "@commercetools/platform-sdk": "^7.7.0",
-    "@commercetools/sdk-client-v2": "^2.4.1",
+    "@commercetools-backend/express": "^22.27.0",
+    "@commercetools-backend/loggers": "^22.27.0",
+    "@commercetools/platform-sdk": "^7.8.0",
+    "@commercetools/sdk-client-v2": "^2.5.0",
     "avatax": "^24.2.0",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",

--- a/service/src/avalara/utils/avatax.config.ts
+++ b/service/src/avalara/utils/avatax.config.ts
@@ -7,7 +7,7 @@ export function avaTaxConfig(env: string, enabled?: boolean, level?: string) {
     appVersion: 'a0o5a000008TO2qAAG',
     machineName: 'v1',
     environment: env,
-    timeout: 5000,
+    timeout: 10000,
     customHttpAgent: new http.Agent({ keepAlive: true }),
     logOptions: {
       logEnabled: !!enabled, // toggle logging on or off, by default its off.

--- a/service/src/avalara/utils/avatax.config.ts
+++ b/service/src/avalara/utils/avatax.config.ts
@@ -5,7 +5,7 @@ export function avaTaxConfig(
   env: string,
   enabled?: boolean,
   level?: string,
-  timeout = 2000
+  timeout = 5000
 ) {
   return {
     appName: 'CommercetoolsbyMediaopt',

--- a/service/src/avalara/utils/avatax.config.ts
+++ b/service/src/avalara/utils/avatax.config.ts
@@ -1,13 +1,18 @@
 // set up avatax client configuration to be used in all calls to avalara
 import * as http from 'node:https';
 
-export function avaTaxConfig(env: string, enabled?: boolean, level?: string) {
+export function avaTaxConfig(
+  env: string,
+  enabled?: boolean,
+  level?: string,
+  timeout = 2000
+) {
   return {
     appName: 'CommercetoolsbyMediaopt',
     appVersion: 'a0o5a000008TO2qAAG',
     machineName: 'v1',
     environment: env,
-    timeout: 10000,
+    timeout,
     customHttpAgent: new http.Agent({ keepAlive: true }),
     logOptions: {
       logEnabled: !!enabled, // toggle logging on or off, by default its off.

--- a/service/src/client/data.client.ts
+++ b/service/src/client/data.client.ts
@@ -30,7 +30,7 @@ export const getBulkCategoryTaxCode = async (cats: Array<string>) => {
   const taxCodes = (
     await createApiRoot()
       .categories()
-      .get({ queryArgs: { where: `id in (${cs})` } })
+      .get({ queryArgs: { where: `id in (${cs})`, limit: 500 } })
       .execute()
   )?.body?.results?.map((x) => ({
     id: x.id,
@@ -50,7 +50,7 @@ export const getBulkProductCategories = async (
     await createApiRoot()
       .productProjections()
       .search()
-      .get({ queryArgs: { filter: ps } })
+      .get({ queryArgs: { filter: ps, limit: 500 } })
       .execute()
   )?.body?.results;
   const result: any = keys.map((x) => ({

--- a/service/src/index.ts
+++ b/service/src/index.ts
@@ -24,7 +24,7 @@ const app: Express = express();
 app.disable('x-powered-by');
 
 // Define configurations
-app.use(bodyParser.json());
+app.use(bodyParser.json({ limit: '16mb' }));
 app.use(bodyParser.urlencoded({ extended: true }));
 
 app.use(cors({ origin: '*.commercetools.com' }));

--- a/service/src/utils/hash.utils.ts
+++ b/service/src/utils/hash.utils.ts
@@ -56,6 +56,14 @@ export function hashCart(cart: Cart) {
       totalPrice: lineItem?.totalPrice,
       includedInPrice: lineItem?.taxRate?.includedInPrice,
     })),
+    customLineItems: cart?.customLineItems.map((customLineItem) => ({
+      avalaraTaxCode: customLineItem?.custom?.fields?.avalaraTaxCode,
+      sku: customLineItem?.name,
+      quantity: customLineItem?.quantity,
+      discounted: customLineItem?.discountedPricePerQuantity,
+      totalPrice: customLineItem?.totalPrice,
+      includedInPrice: customLineItem?.taxRate?.includedInPrice,
+    })),
     shippingInfo: {
       id: cart?.shippingInfo?.shippingMethod?.id,
       price: cart?.shippingInfo?.price,

--- a/service/tests/avalara.response.validation.ts
+++ b/service/tests/avalara.response.validation.ts
@@ -80,7 +80,7 @@ export const actions = {
     {
       action: 'setCustomField',
       name: 'avalaraHash',
-      value: '447bf31f9fc955c798d259ffb2b4d47a',
+      value: 'ae6a3c3af8b7caeb6ff3e397ea552afd',
     },
   ],
 };

--- a/service/tests/client.spec.ts
+++ b/service/tests/client.spec.ts
@@ -78,7 +78,7 @@ describe('test coco api client', () => {
     expect(apiRoot.productProjections).toBeCalledTimes(1);
     expect(apiRoot.search).toBeCalledTimes(1);
     expect(apiRoot.get).toBeCalledWith({
-      queryArgs: { filter: `variants.sku:"sku123","sku456"` },
+      queryArgs: { filter: `variants.sku:"sku123","sku456"`, limit: 500 },
     });
     expect(apiRoot.execute).toBeCalledTimes(1);
 
@@ -94,7 +94,7 @@ describe('test coco api client', () => {
     const data = await getBulkCategoryTaxCode(['123', '456']);
     expect(apiRoot.categories).toBeCalledTimes(1);
     expect(apiRoot.get).toBeCalledWith({
-      queryArgs: { where: `id in ("123", "456")` },
+      queryArgs: { where: `id in ("123", "456")`, limit: 500 },
     });
     expect(apiRoot.execute).toBeCalledTimes(1);
 

--- a/service/tests/service.test.connection.spec.ts
+++ b/service/tests/service.test.connection.spec.ts
@@ -56,7 +56,7 @@ describe('test test connection controller', () => {
         logRequestAndResponseInfo: true,
       },
       machineName: 'v1',
-      timeout: 5000,
+      timeout: 10000,
     });
 
     SpyAvatax.mockRestore();

--- a/service/tests/service.test.connection.spec.ts
+++ b/service/tests/service.test.connection.spec.ts
@@ -1,10 +1,19 @@
-import { describe, expect, test, jest, afterEach } from '@jest/globals';
+import {
+  describe,
+  expect,
+  test,
+  jest,
+  afterEach,
+  beforeEach,
+} from '@jest/globals';
 import { postTestConnection } from '../src/controllers/test.connection.controller';
 import { NextFunction, Request, Response } from 'express';
 import CustomError from '../src/errors/custom.error';
 import * as moduleAvaTax from 'avatax/lib/AvaTaxClient';
 import * as http from 'node:https';
 import { PingResultModel } from 'avatax/lib/models/PingResultModel';
+import * as moduleAvataxConfig from '../src/avalara/utils/avatax.config';
+import { config } from './test.data';
 
 const response = {
   json: jest.fn(),
@@ -12,6 +21,9 @@ const response = {
 } as unknown as Response;
 
 describe('test test connection controller', () => {
+  beforeEach(() => {
+    jest.spyOn(moduleAvataxConfig, 'avaTaxConfig').mockReturnValue(config);
+  });
   afterEach(() => {
     jest.clearAllMocks();
   });
@@ -45,19 +57,7 @@ describe('test test connection controller', () => {
       response,
       jest.fn()
     );
-    expect(SpyAvatax).toHaveBeenCalledWith({
-      appName: 'CommercetoolsbyMediaopt',
-      appVersion: 'a0o5a000008TO2qAAG',
-      customHttpAgent: expect.any(http.Agent),
-      environment: process.env.AVALARA_ENV,
-      logOptions: {
-        logEnabled: true, // toggle logging on or off, by default its off.
-        logLevel: 2, // logLevel that will be used, Options are LogLevel.Error (0), LogLevel.Warn (1), LogLevel.Info (2), LogLevel.Debug (3)
-        logRequestAndResponseInfo: true,
-      },
-      machineName: 'v1',
-      timeout: 10000,
-    });
+    expect(SpyAvatax).toHaveBeenCalledWith(config);
 
     SpyAvatax.mockRestore();
   });

--- a/service/tests/service.update.cart.spec.ts
+++ b/service/tests/service.update.cart.spec.ts
@@ -1,4 +1,11 @@
-import { describe, expect, test, jest, afterEach } from '@jest/globals';
+import {
+  describe,
+  expect,
+  test,
+  jest,
+  afterEach,
+  beforeEach,
+} from '@jest/globals';
 import { TransactionModel } from 'avatax/lib/models/TransactionModel';
 import { NextFunction, Request, Response } from 'express';
 import { fullCart, emptyCart, cartRequest } from './carts';
@@ -6,7 +13,9 @@ import * as moduleAvaTax from 'avatax/lib/AvaTaxClient';
 import { post } from '../src/controllers/service.controller';
 import * as http from 'node:https';
 import CustomError from '../src/errors/custom.error';
+import * as moduleAvataxConfig from '../src/avalara/utils/avatax.config';
 import { actions, expectAvaTaxReturn } from './avalara.response.validation';
+import { config } from './test.data';
 import {
   avalaraMerchantDataBody,
   bulkCategoryTaxCodeBody,
@@ -80,6 +89,9 @@ const serviceThrowCases = [
 ];
 
 describe('test service/cart controller', () => {
+  beforeEach(() => {
+    jest.spyOn(moduleAvataxConfig, 'avaTaxConfig').mockReturnValue(config);
+  });
   afterEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
@@ -217,19 +229,7 @@ describe('test service/cart controller', () => {
       response,
       next
     );
-    expect(SpyAvatax).toHaveBeenCalledWith({
-      appName: 'CommercetoolsbyMediaopt',
-      appVersion: 'a0o5a000008TO2qAAG',
-      customHttpAgent: expect.any(http.Agent),
-      environment: process.env.AVALARA_ENV,
-      logOptions: {
-        logEnabled: true, // toggle logging on or off, by default its off.
-        logLevel: 2, // logLevel that will be used, Options are LogLevel.Error (0), LogLevel.Warn (1), LogLevel.Info (2), LogLevel.Debug (3)
-        logRequestAndResponseInfo: true,
-      },
-      machineName: 'v1',
-      timeout: 10000,
-    });
+    expect(SpyAvatax).toHaveBeenCalledWith(config);
 
     SpyAvatax.mockRestore();
   });

--- a/service/tests/service.update.cart.spec.ts
+++ b/service/tests/service.update.cart.spec.ts
@@ -125,7 +125,7 @@ describe('test service/cart controller', () => {
           streetNumber: '2000',
           postalCode: '92614',
         },
-        'fbd553eec940799f2b23fcd40d5cd36e'
+        '9952a1641782875e8e868a11c421ae0b'
       )
     ),
   ])(
@@ -228,7 +228,7 @@ describe('test service/cart controller', () => {
         logRequestAndResponseInfo: true,
       },
       machineName: 'v1',
-      timeout: 5000,
+      timeout: 10000,
     });
 
     SpyAvatax.mockRestore();

--- a/service/tests/service.validate.address.spec.ts
+++ b/service/tests/service.validate.address.spec.ts
@@ -106,7 +106,7 @@ describe('test check address controller', () => {
           logRequestAndResponseInfo: true,
         },
         machineName: 'v1',
-        timeout: 5000,
+        timeout: 10000,
       });
     }
   );

--- a/service/tests/service.validate.address.spec.ts
+++ b/service/tests/service.validate.address.spec.ts
@@ -1,4 +1,11 @@
-import { describe, expect, test, jest, afterEach } from '@jest/globals';
+import {
+  describe,
+  expect,
+  test,
+  jest,
+  afterEach,
+  beforeEach,
+} from '@jest/globals';
 import { postCheckAddress } from '../src/controllers/check.address.controller';
 import * as moduleAvaTax from 'avatax/lib/AvaTaxClient';
 import * as http from 'node:https';
@@ -6,6 +13,8 @@ import { NextFunction, Request, Response } from 'express';
 import { avalaraMerchantDataBody } from './test.data';
 import CustomError from '../src/errors/custom.error';
 import { AddressResolutionModel } from 'avatax/lib/models/AddressResolutionModel';
+import * as moduleAvataxConfig from '../src/avalara/utils/avatax.config';
+import { config } from './test.data';
 
 const apiRoot: any = {
   customObjects: jest.fn(() => apiRoot),
@@ -69,6 +78,9 @@ const validRequests = (isValidAddress: boolean) => {
 };
 
 describe('test check address controller', () => {
+  beforeEach(() => {
+    jest.spyOn(moduleAvataxConfig, 'avaTaxConfig').mockReturnValue(config);
+  });
   afterEach(() => {
     jest.clearAllMocks();
     jest.restoreAllMocks();
@@ -95,19 +107,7 @@ describe('test check address controller', () => {
       } else {
         expect(apiRoot.execute).toBeCalledTimes(0);
       }
-      expect(SpyAvatax).toHaveBeenCalledWith({
-        appName: 'CommercetoolsbyMediaopt',
-        appVersion: 'a0o5a000008TO2qAAG',
-        customHttpAgent: expect.any(http.Agent),
-        environment: process.env.AVALARA_ENV,
-        logOptions: {
-          logEnabled: true, // toggle logging on or off, by default its off.
-          logLevel: 2, // logLevel that will be used, Options are LogLevel.Error (0), LogLevel.Warn (1), LogLevel.Info (2), LogLevel.Debug (3)
-          logRequestAndResponseInfo: true,
-        },
-        machineName: 'v1',
-        timeout: 10000,
-      });
+      expect(SpyAvatax).toHaveBeenCalledWith(config);
     }
   );
 

--- a/service/tests/test.data.ts
+++ b/service/tests/test.data.ts
@@ -1,3 +1,4 @@
+import { avaTaxConfig } from '../src/avalara/utils/avatax.config';
 import { AvataxMerchantConfig } from '../src/types/index.types';
 
 export const avalaraMerchantDataBody = {
@@ -95,3 +96,5 @@ export const bulkProductCategoriesBody = {
     ],
   },
 };
+
+export const config = avaTaxConfig('sandbox', true, '2', 10000);

--- a/service/yarn.lock
+++ b/service/yarn.lock
@@ -329,10 +329,10 @@
   resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.6.0.tgz#ec6cd237440700bc23ca23087f513c75508958b0"
   integrity sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==
 
-"@commercetools-backend/express@^22.15.0":
-  version "22.23.3"
-  resolved "https://registry.yarnpkg.com/@commercetools-backend/express/-/express-22.23.3.tgz#8638694642c6767e6d9a1a2461ea07dcd80b1d4c"
-  integrity sha512-6oicIQqEu/eVCPKhkclpCSJHeLyfwKnjGJPp5siolUNd34ovmGIIF4/yQU9jdD05bs9o4sOFxBH/JMyFZyIF2g==
+"@commercetools-backend/express@^22.27.0":
+  version "22.27.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-backend/express/-/express-22.27.0.tgz#92df4f0391033e9ac9b672ce62be2725324922df"
+  integrity sha512-yO9gfhKwhPRxhbCOObmxg1Q+ex45cuKq+qOGELanZjAywX05kGY6Zh6iBa5c/Pvi3tlPE8DgGhmtNySHSsjloQ==
   dependencies:
     "@babel/runtime" "^7.22.15"
     "@babel/runtime-corejs3" "^7.22.15"
@@ -342,10 +342,10 @@
     express-jwt "8.4.1"
     jwks-rsa "2.1.5"
 
-"@commercetools-backend/loggers@^22.23.3":
-  version "22.23.3"
-  resolved "https://registry.yarnpkg.com/@commercetools-backend/loggers/-/loggers-22.23.3.tgz#11f00b1e0d5d3adbb96a6a05aeb2d0cc0e302a2c"
-  integrity sha512-d7Y7Jjozp9xVl1dEn2viqgaxuZmSaFMeylJ5HGNKserNfl3hzb0ltzS1lNibG8wMVzs6DXI34EJMomJ5XhJsiw==
+"@commercetools-backend/loggers@^22.27.0":
+  version "22.27.0"
+  resolved "https://registry.yarnpkg.com/@commercetools-backend/loggers/-/loggers-22.27.0.tgz#f56a42235548aff8c9bb1e321100dfbd33403c27"
+  integrity sha512-wgm01cD8cawuMGOwQsxQbhbkyS8ALkwPOGE63TyLqoS3MLVmvOk3e9Eg/YxpfjXu7cbbi+29cqWwxF5dUiV63w==
   dependencies:
     "@babel/runtime" "^7.22.15"
     "@babel/runtime-corejs3" "^7.22.15"
@@ -356,23 +356,23 @@
     lodash "4.17.21"
     logform "2.6.0"
     triple-beam "1.4.1"
-    winston "3.12.0"
+    winston "3.13.0"
 
-"@commercetools/platform-sdk@^7.7.0":
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/@commercetools/platform-sdk/-/platform-sdk-7.7.0.tgz#cb29b5a337e78f24ddd81dc9ba36bcbf0cb914bc"
-  integrity sha512-9RpgjwYOAFhKKWLKaefXfWoz8siC3gH4inOhHYVVcIhQm8pkRX5dLbNLOE/AX7FpatcTHX65ws9OHuifHh+Quw==
+"@commercetools/platform-sdk@^7.8.0":
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/@commercetools/platform-sdk/-/platform-sdk-7.8.0.tgz#9b218fc65d64b84c00fc9515a4435bc39d07ae62"
+  integrity sha512-7dpUG8kVULm286dyL1N5IZ6A+0iNwjHdeck7CZdUkVeJ697XN/YwPQkjQ2z62ZkaJRL0efPN5277TWttsU6uLA==
   dependencies:
-    "@commercetools/sdk-client-v2" "^2.4.1"
+    "@commercetools/sdk-client-v2" "^2.5.0"
     "@commercetools/sdk-middleware-auth" "^7.0.0"
     "@commercetools/sdk-middleware-http" "^7.0.0"
     "@commercetools/sdk-middleware-logger" "^3.0.0"
-    "@commercetools/ts-client" "^1.2.0"
+    "@commercetools/ts-client" "^1.2.1"
 
-"@commercetools/sdk-client-v2@^2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@commercetools/sdk-client-v2/-/sdk-client-v2-2.4.1.tgz#d36416181893fb08d746c10d555138a9c1428c70"
-  integrity sha512-zhsQz8dN/6D+kLyO8xX2SLppf3VcP0AWc80abmGwY2k1c+psb7s9xCCRZC553X+CZP8Z+2ajZ5PjTHnZxVMSjQ==
+"@commercetools/sdk-client-v2@^2.5.0":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@commercetools/sdk-client-v2/-/sdk-client-v2-2.5.0.tgz#3fe33f733d059472896f4fd0820cf899a30cd150"
+  integrity sha512-v1y++O6yllG+IRTYm9jPE8s667+GapnysyGIf8NJDZbVwhvcanixZL4d20imXjCpOr4u1iZrgRftc90mgYqblw==
   dependencies:
     buffer "^6.0.3"
     node-fetch "^2.6.1"
@@ -394,15 +394,15 @@
   resolved "https://registry.yarnpkg.com/@commercetools/sdk-middleware-logger/-/sdk-middleware-logger-3.0.0.tgz#4bfc7441d485b3f1046001f44200d12926accb84"
   integrity sha512-DhMXAA2yIch/AaGxy7st85Z1HFmeLtHWGkr9z5rX4xKjan4PHGB/IE5saAR+SNGHhs6+1Lp8vZEHDo3tFqVLmg==
 
-"@commercetools/ts-client@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@commercetools/ts-client/-/ts-client-1.2.0.tgz#5137534cc2fd787ad99ee318e383c753c4e0a547"
-  integrity sha512-oMuv9AFFyx/lbkbw+/AYpUGPUNMa1AiCgAcAVU798fOHMrDn3/NrVmuMM+PDwaPoTISUUUoPRheMNXSwprxHrw==
+"@commercetools/ts-client@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@commercetools/ts-client/-/ts-client-1.2.1.tgz#4bc1076c56f51ce0b0603e8afe4d84e67b09202c"
+  integrity sha512-tgy78lQoEoqYoK0KeSj43/v1Mg17M1ouwXtDxKmjAqEW4RyiCGOPPjOiZT9adTyjbK4CcOcwDzJxUVziIerg5g==
   dependencies:
     abort-controller "3.0.0"
     buffer "^6.0.3"
     node-fetch "^2.6.1"
-    uuid "9.0.0"
+    uuid "9.0.1"
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -4160,10 +4160,10 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
-  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+uuid@9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
@@ -4225,10 +4225,10 @@ winston-transport@^4.7.0:
     readable-stream "^3.6.0"
     triple-beam "^1.3.0"
 
-winston@3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.12.0.tgz#a5d965a41d3dc31be5408f8c66e927958846c0d0"
-  integrity sha512-OwbxKaOlESDi01mC9rkM0dQqQt2I8DAUMRLZ/HpbwvDXm85IryEHgoogy5fziQy38PntgZsLlhAYHz//UPHZ5w==
+winston@3.13.0:
+  version "3.13.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.13.0.tgz#e76c0d722f78e04838158c61adc1287201de7ce3"
+  integrity sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==
   dependencies:
     "@colors/colors" "^1.6.0"
     "@dabh/diagnostics" "^2.0.2"


### PR DESCRIPTION
- Increased default body size in express to maximum allowed by commercetools for large carts/orders
- Increased limit of query entities sent to commercetools API to maximum possible value in case of large carts
- Added custom line items to hash
- Increased Avalara timeout
- Adjusted tests for the above changes
- Updated dependencies