### PR TITLE
Bugfix/36735 unpublished products in cart

### DIFF
--- a/event/src/avalara/requests/preprocess/get.categories.ts
+++ b/event/src/avalara/requests/preprocess/get.categories.ts
@@ -13,33 +13,22 @@ export async function getCategoryTaxCodes(items: Array<LineItem>) {
     )
     ?.map((x) => x.variant?.sku);
 
-  const categoryData =
-    itemsWithoutTaxCodes.length !== 0
-      ? await getBulkProductCategories(itemsWithoutTaxCodes)
-      : [];
+  const categoryData = await getBulkProductCategories(itemsWithoutTaxCodes);
 
-  const listOfCategories: any =
-    categoryData.length !== 0
-      ? [
+  const listOfCategories: any = [
           ...new Set(
             categoryData
               .map((x: any) => x.categories)
               .reduce((acc: any, curr: any) => curr?.concat(acc), [])
           ),
-        ]
-      : [];
+        ];
 
-  const catTaxCodes =
-    listOfCategories.length !== 0
-      ? await getBulkCategoryTaxCode(listOfCategories)
-      : [];
+  const catTaxCodes = await getBulkCategoryTaxCode(listOfCategories);
 
-  return listOfCategories.length !== 0
-    ? categoryData.map((x: any) => ({
+  return categoryData.map((x: any) => ({
         sku: x.sku,
         taxCode: x.categories
           .map((x: any) => catTaxCodes?.find((y) => y.id === x)?.avalaraTaxCode)
           .find((x: any) => x !== undefined),
-      }))
-    : [];
+      }));
 }

--- a/event/src/avalara/utils/line.items.ts
+++ b/event/src/avalara/utils/line.items.ts
@@ -15,7 +15,7 @@ function itemTaxCode(item: LineItem) {
 export function lineItem(
   type: string,
   item: LineItem,
-  catTaxCodes: [{ [key: string]: string }]
+  catTaxCodes: { sku: string; taxCode: string }[]
 ) {
   const lineItem = new LineItemModel();
 

--- a/event/src/client/data.client.ts
+++ b/event/src/client/data.client.ts
@@ -1,78 +1,119 @@
+import { logger } from '../utils/logger.utils';
 import { createApiRoot } from './create.client';
+import { Order } from '@commercetools/platform-sdk';
 
 export const getData = async (container: string) => {
-  const data = (
-    await createApiRoot()
-      .customObjects()
-      .withContainer({ container: container })
-      .get()
-      .execute()
-  )?.body?.results;
-  return data
-    .map((x) => ({ [x.key]: x.value }))
-    .reduce((acc, curr) => Object.assign(acc, curr), {});
+  try {
+    return (
+      await createApiRoot()
+        .customObjects()
+        .withContainer({ container: container })
+        .get()
+        .execute()
+    )?.body?.results
+      .map((x) => ({ [x.key]: x.value }))
+      .reduce((acc, curr) => Object.assign(acc, curr), {});
+  } catch (e) {
+    logger.error(e);
+    return {};
+  }
 };
 
 export const getShipTaxCode = async (id: string) => {
-  return (
-    await createApiRoot().shippingMethods().withId({ ID: id }).get().execute()
-  )?.body?.custom?.fields?.avalaraTaxCode as string;
+  try {
+    return (
+      await createApiRoot().shippingMethods().withId({ ID: id }).get().execute()
+    )?.body?.custom?.fields?.avalaraTaxCode as string;
+  } catch (e) {
+    logger.error(e);
+    return '';
+  }
 };
 
 export const getCustomerEntityUseCode = async (id: string) => {
-  const customer = (
-    await createApiRoot().customers().withId({ ID: id }).get().execute()
-  )?.body;
-  return {
-    customerNumber: customer?.customerNumber || id,
-    exemptCode: customer?.custom?.fields?.avalaraEntityUseCode as string,
-  };
+  try {
+    const customer = (
+      await createApiRoot().customers().withId({ ID: id }).get().execute()
+    )?.body;
+    return {
+      customerNumber: customer?.customerNumber || id,
+      exemptCode: customer?.custom?.fields?.avalaraEntityUseCode as string,
+    };
+  } catch (e) {
+    logger.error(e);
+    return { customerNumber: id, exemptCode: '' };
+  }
 };
 
-export const getBulkCategoryTaxCode = async (cats: Array<string>) => {
-  const cs = cats
-    .map((x) => `"${x}", `)
-    .reduce((acc, curr) => acc + curr, '')
-    .slice(0, -2);
-  const taxCodes = (
-    await createApiRoot()
-      .categories()
-      .get({ queryArgs: { where: `id in (${cs})`, limit: 500 } })
-      .execute()
-  )?.body?.results.map((x) => ({
-    id: x.id,
-    avalaraTaxCode: x.custom?.fields?.avalaraTaxCode,
-  }));
-  return taxCodes;
+export const getBulkCategoryTaxCode = async (categories: Array<string>) => {
+  if (!categories.length) return [];
+  try {
+    return (
+      await createApiRoot()
+        .categories()
+        .get({
+          queryArgs: {
+            where: `id in (${categories
+              .map((x) => `"${x}", `)
+              .reduce((acc, curr) => acc + curr, '')
+              .slice(0, -2)})`,
+            limit: 500,
+          },
+        })
+        .execute()
+    )?.body?.results.map((x) => ({
+      id: x.id,
+      avalaraTaxCode: x.custom?.fields?.avalaraTaxCode as string,
+    }));
+  } catch (e) {
+    logger.error(e);
+    return [];
+  }
 };
 
 export const getBulkProductCategories = async (
   keys: Array<string | undefined>
 ) => {
-  const ps = keys
-    .map((x) => `"${x}",`)
-    .reduce((acc, curr) => acc + curr, 'variants.sku:')
-    .slice(0, -1);
-  const data = (
-    await createApiRoot()
-      .productProjections()
-      .search()
-      .get({ queryArgs: { filter: ps, limit: 500 } })
-      .execute()
-  )?.body?.results;
-  const result: any = keys.map((x) => ({
-    sku: x,
-    categories: data
-      .find(
-        (y) =>
-          y?.masterVariant?.sku === x || y?.variants?.find((z) => z?.sku === x)
-      )
-      ?.categories.map((x: any) => x.id),
-  }));
-  return result;
+  try {
+    const data = (
+      await createApiRoot()
+        .productProjections()
+        .search()
+        .get({
+          queryArgs: {
+            filter: keys
+              .map((x) => `"${x}",`)
+              .reduce((acc, curr) => acc + curr, 'variants.sku:')
+              .slice(0, -1),
+            limit: 500,
+          },
+        })
+        .execute()
+    )?.body?.results;
+    return keys
+      .map((x) => ({
+        sku: x as string,
+        categories: data
+          .find(
+            (y) =>
+              y?.masterVariant?.sku === x ||
+              y?.variants?.find((z) => z?.sku === x)
+          )
+          ?.categories.map((x: any) => x.id) as string[],
+      }))
+      .filter((x) => x.categories && x.categories.length);
+  } catch (e) {
+    logger.error(e);
+    return [];
+  }
 };
 
 export const getOrder = async (id: string) => {
-  return (await createApiRoot().orders().withId({ ID: id }).get().execute())
-    .body;
+  try {
+    return (await createApiRoot().orders().withId({ ID: id }).get().execute())
+      .body;
+  } catch (e) {
+    logger.error(e);
+    return {} as Order;
+  }
 };

--- a/event/src/client/data.client.ts
+++ b/event/src/client/data.client.ts
@@ -15,7 +15,7 @@ export const getData = async (container: string) => {
       .reduce((acc, curr) => Object.assign(acc, curr), {});
   } catch (e) {
     logger.error(e);
-    return {};
+    return undefined;
   }
 };
 
@@ -26,7 +26,7 @@ export const getShipTaxCode = async (id: string) => {
     )?.body?.custom?.fields?.avalaraTaxCode as string;
   } catch (e) {
     logger.error(e);
-    return '';
+    return undefined;
   }
 };
 
@@ -41,7 +41,7 @@ export const getCustomerEntityUseCode = async (id: string) => {
     };
   } catch (e) {
     logger.error(e);
-    return { customerNumber: id, exemptCode: '' };
+    return { customerNumber: id, exemptCode: undefined };
   }
 };
 
@@ -74,6 +74,7 @@ export const getBulkCategoryTaxCode = async (categories: Array<string>) => {
 export const getBulkProductCategories = async (
   keys: Array<string | undefined>
 ) => {
+  if (!keys.length) return [];
   try {
     const data = (
       await createApiRoot()

--- a/event/tests/client.spec.ts
+++ b/event/tests/client.spec.ts
@@ -48,9 +48,18 @@ describe('test coco api client', () => {
     });
     expect(apiRoot.get).toBeCalledTimes(1);
     expect(apiRoot.execute).toBeCalledTimes(1);
-
     expect(data).toBeDefined();
     expect(Object.keys(data?.settings).length).toBe(12);
+  });
+
+  test('get avalara merchant data method fails', async () => {
+    apiRoot.execute = jest.fn(() => {
+      throw new Error('error');
+    });
+    const data = await getData('avalara-connector-settings');
+    expect(apiRoot.execute).toBeCalledTimes(1);
+    expect(apiRoot.execute).toThrowError();
+    expect(data).toEqual({});
   });
 
   test('get shipping tax code method', async () => {
@@ -60,8 +69,17 @@ describe('test coco api client', () => {
     expect(apiRoot.withId).toBeCalledWith({ ID: '123' });
     expect(apiRoot.get).toBeCalledTimes(1);
     expect(apiRoot.execute).toBeCalledTimes(1);
-
     expect(data).toBe('PC030000');
+  });
+
+  test('get shipping tax code method fails', async () => {
+    apiRoot.execute = jest.fn(() => {
+      throw new Error('error');
+    });
+    const data = await getShipTaxCode('123');
+    expect(apiRoot.execute).toBeCalledTimes(1);
+    expect(apiRoot.execute).toThrowError();
+    expect(data).toBe('');
   });
 
   test('get customer entity use code method', async () => {
@@ -74,6 +92,17 @@ describe('test coco api client', () => {
 
     expect(data.customerNumber).toBe('123');
     expect(data.exemptCode).toBe('B');
+  });
+
+  test('get customer entity use code method fails', async () => {
+    apiRoot.execute = jest.fn(() => {
+      throw new Error('error');
+    });
+    const data = await getCustomerEntityUseCode('123');
+    expect(apiRoot.execute).toBeCalledTimes(1);
+    expect(apiRoot.execute).toThrowError();
+    expect(data.customerNumber).toBe('123');
+    expect(data.exemptCode).toBe('');
   });
 
   test('get all categories of a list of products', async () => {
@@ -91,6 +120,16 @@ describe('test coco api client', () => {
     expect(data[0]?.categories[0]).toBe('123');
     expect(data[1]?.sku).toBe('sku456');
     expect(data[1]?.categories[0]).toBe('456');
+  });
+
+  test('get all categories of a list of products fails', async () => {
+    apiRoot.execute = jest.fn(() => {
+      throw new Error('error');
+    });
+    const data = await getBulkProductCategories(['sku123', 'sku456']);
+    expect(apiRoot.execute).toBeCalledTimes(1);
+    expect(apiRoot.execute).toThrowError();
+    expect(data).toEqual([]);
   });
 
   test('get all tax codes of a list of categories', async () => {
@@ -111,6 +150,16 @@ describe('test coco api client', () => {
     expect(data[1]?.avalaraTaxCode).toBe('PS080101');
   });
 
+  test('get all tax codes of a list of categories fails', async () => {
+    apiRoot.execute = jest.fn(() => {
+      throw new Error('error');
+    });
+    const data = await getBulkCategoryTaxCode(['123', '456']);
+    expect(apiRoot.execute).toBeCalledTimes(1);
+    expect(apiRoot.execute).toThrowError();
+    expect(data).toEqual([]);
+  });
+
   test('get order', async () => {
     apiRoot.execute = jest.fn(() => orderRequest('123', 'US'));
     const data = await getOrder('123');
@@ -122,5 +171,15 @@ describe('test coco api client', () => {
     expect(data).toBeDefined();
     expect(data?.id).toBe('123');
     expect(data?.shippingAddress?.country).toBe('US');
+  });
+
+  test('get order fails', async () => {
+    apiRoot.execute = jest.fn(() => {
+      throw new Error('error');
+    });
+    const data = await getOrder('123');
+    expect(apiRoot.execute).toBeCalledTimes(1);
+    expect(apiRoot.execute).toThrowError();
+    expect(data).toEqual({});
   });
 });

--- a/event/tests/client.spec.ts
+++ b/event/tests/client.spec.ts
@@ -39,7 +39,7 @@ describe('test coco api client', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-  test('get avalara merchant data method', async () => {
+  test('get avalara merchant data method succeeds', async () => {
     apiRoot.execute = jest.fn(() => avalaraMerchantDataBody(false));
     const data = await getData('avalara-connector-settings');
     expect(apiRoot.customObjects).toBeCalledTimes(1);
@@ -62,7 +62,7 @@ describe('test coco api client', () => {
     expect(data).toBeUndefined();
   });
 
-  test('get shipping tax code method', async () => {
+  test('get shipping tax code method succeeds', async () => {
     apiRoot.execute = jest.fn(() => shipTaxCodeBody('PC030000'));
     const data = await getShipTaxCode('123');
     expect(apiRoot.shippingMethods).toBeCalledTimes(1);
@@ -82,7 +82,7 @@ describe('test coco api client', () => {
     expect(data).toBeUndefined();
   });
 
-  test('get customer entity use code method', async () => {
+  test('get customer entity use code method succeeds', async () => {
     apiRoot.execute = jest.fn(() => entityUseCodeBody('B'));
     const data = await getCustomerEntityUseCode('123');
     expect(apiRoot.customers).toBeCalledTimes(1);
@@ -105,7 +105,7 @@ describe('test coco api client', () => {
     expect(data?.exemptCode).toBeUndefined();
   });
 
-  test('get all categories of a list of products', async () => {
+  test('get all categories of a list of products succeeds', async () => {
     apiRoot.execute = jest.fn(() => bulkProductCategoriesBody);
     const data = await getBulkProductCategories(['sku123', 'sku456']);
     expect(apiRoot.productProjections).toBeCalledTimes(1);
@@ -132,7 +132,7 @@ describe('test coco api client', () => {
     expect(data).toEqual([]);
   });
 
-  test('get all tax codes of a list of categories', async () => {
+  test('get all tax codes of a list of categories succeeds', async () => {
     apiRoot.execute = jest.fn(() =>
       bulkCategoryTaxCodeBody(['PS081282', 'PS080101'])
     );
@@ -160,7 +160,7 @@ describe('test coco api client', () => {
     expect(data).toEqual([]);
   });
 
-  test('get order', async () => {
+  test('get order succeeds', async () => {
     apiRoot.execute = jest.fn(() => orderRequest('123', 'US'));
     const data = await getOrder('123');
     expect(apiRoot.orders).toBeCalledTimes(1);

--- a/event/tests/client.spec.ts
+++ b/event/tests/client.spec.ts
@@ -59,7 +59,7 @@ describe('test coco api client', () => {
     const data = await getData('avalara-connector-settings');
     expect(apiRoot.execute).toBeCalledTimes(1);
     expect(apiRoot.execute).toThrowError();
-    expect(data).toEqual({});
+    expect(data).toBeUndefined();
   });
 
   test('get shipping tax code method', async () => {
@@ -79,7 +79,7 @@ describe('test coco api client', () => {
     const data = await getShipTaxCode('123');
     expect(apiRoot.execute).toBeCalledTimes(1);
     expect(apiRoot.execute).toThrowError();
-    expect(data).toBe('');
+    expect(data).toBeUndefined();
   });
 
   test('get customer entity use code method', async () => {
@@ -90,8 +90,8 @@ describe('test coco api client', () => {
     expect(apiRoot.get).toBeCalledTimes(1);
     expect(apiRoot.execute).toBeCalledTimes(1);
 
-    expect(data.customerNumber).toBe('123');
-    expect(data.exemptCode).toBe('B');
+    expect(data?.customerNumber).toBe('123');
+    expect(data?.exemptCode).toBe('B');
   });
 
   test('get customer entity use code method fails', async () => {
@@ -101,8 +101,8 @@ describe('test coco api client', () => {
     const data = await getCustomerEntityUseCode('123');
     expect(apiRoot.execute).toBeCalledTimes(1);
     expect(apiRoot.execute).toThrowError();
-    expect(data.customerNumber).toBe('123');
-    expect(data.exemptCode).toBe('');
+    expect(data?.customerNumber).toBe('123');
+    expect(data?.exemptCode).toBeUndefined();
   });
 
   test('get all categories of a list of products', async () => {

--- a/event/tests/event.spec.ts
+++ b/event/tests/event.spec.ts
@@ -371,15 +371,4 @@ describe('test event controller', () => {
     );
     expect(response.send).toBeCalledTimes(0);
   });
-
-  test('api Root throws an error', async () => {
-    const next = jest.fn() as NextFunction;
-    apiRoot.execute = jest.fn(() => {
-      throw new Error('apiRoot error');
-    });
-    await post(commitRequest('US'), response, next);
-    expect(next).toBeCalledTimes(1);
-    expect(next).toBeCalledWith(new CustomError(400, 'apiRoot error'));
-    expect(response.send).toBeCalledTimes(0);
-  });
 });

--- a/mc-app/package.json
+++ b/mc-app/package.json
@@ -102,7 +102,8 @@
     "react-redux": "7.2.9",
     "react-router-dom": "5.3.4",
     "redux": "4.2.1",
-    "typescript": "5.0.4"
+    "typescript": "5.0.4",
+    "ws": "8.17.1"
   },
   "resolutions": {
     "@emotion/react": "11.11.4",
@@ -112,6 +113,7 @@
     "@types/react-dom": "<18",
     "@types/react-router": "<6",
     "@types/react-router-dom": "<6",
-    "braces": "^3.0.3"
+    "braces": "^3.0.3",
+    "ws": "^8.17.1"
   }
 }

--- a/mc-app/yarn.lock
+++ b/mc-app/yarn.lock
@@ -13578,6 +13578,11 @@ ws@8.13.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
   integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
 
+ws@8.17.1:
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+
 ws@^7.3.1:
   version "7.5.9"
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"

--- a/service/src/avalara/requests/preprocess/get.categories.ts
+++ b/service/src/avalara/requests/preprocess/get.categories.ts
@@ -13,33 +13,22 @@ export async function getCategoryTaxCodes(items: Array<LineItem>) {
     )
     ?.map((x) => x.variant?.sku);
 
-  const categoryData =
-    itemsWithoutTaxCodes.length !== 0
-      ? await getBulkProductCategories(itemsWithoutTaxCodes)
-      : [];
+  const categoryData = await getBulkProductCategories(itemsWithoutTaxCodes);
 
-  const listOfCategories: any =
-    categoryData.length !== 0
-      ? [
-          ...new Set(
-            categoryData
-              .map((x: any) => x.categories)
-              .reduce((acc: any, curr: any) => curr?.concat(acc), [])
-          ),
-        ]
-      : [];
+  const listOfCategories: any = [
+    ...new Set(
+      categoryData
+        .map((x: any) => x.categories)
+        .reduce((acc: any, curr: any) => curr?.concat(acc), [])
+    ),
+  ];
 
-  const catTaxCodes =
-    listOfCategories.length !== 0
-      ? await getBulkCategoryTaxCode(listOfCategories)
-      : [];
+  const catTaxCodes = await getBulkCategoryTaxCode(listOfCategories);
 
-  return listOfCategories.length !== 0
-    ? categoryData.map((x: any) => ({
-        sku: x.sku,
-        taxCode: x.categories
-          .map((x: any) => catTaxCodes.find((y) => y.id === x)?.avalaraTaxCode)
-          .find((x: any) => x !== undefined),
-      }))
-    : [];
+  return categoryData.map((x: any) => ({
+    sku: x.sku,
+    taxCode: x.categories
+      .map((x: any) => catTaxCodes.find((y) => y.id === x)?.avalaraTaxCode)
+      .find((x: any) => x !== undefined),
+  }));
 }

--- a/service/src/avalara/utils/line.items.ts
+++ b/service/src/avalara/utils/line.items.ts
@@ -15,7 +15,7 @@ function itemTaxCode(item: LineItem) {
 
 export function lineItem(
   item: LineItem,
-  catTaxCodes: { sku: any; taxCode: any }[]
+  catTaxCodes: { sku: string; taxCode: string }[]
 ) {
   const lineItem = new LineItemModel();
 

--- a/service/src/client/data.client.ts
+++ b/service/src/client/data.client.ts
@@ -14,7 +14,7 @@ export const getData = async (container: string) => {
       ?.reduce((acc, curr) => Object.assign(acc, curr), {});
   } catch (e) {
     logger.error(e);
-    return {};
+    return undefined;
   }
 };
 
@@ -25,7 +25,7 @@ export const getShipTaxCode = async (id: string) => {
     )?.body?.custom?.fields?.avalaraTaxCode as string;
   } catch (e) {
     logger.error(e);
-    return '';
+    return undefined;
   }
 };
 
@@ -36,7 +36,7 @@ export const getCustomerEntityUseCode = async (id: string) => {
     )?.body?.custom?.fields?.avalaraEntityUseCode as string;
   } catch (e) {
     logger.error(e);
-    return '';
+    return undefined;
   }
 };
 
@@ -69,6 +69,7 @@ export const getBulkCategoryTaxCode = async (categories: Array<string>) => {
 export const getBulkProductCategories = async (
   keys: Array<string | undefined>
 ) => {
+  if (!keys.length) return [];
   try {
     const data = (
       await createApiRoot()

--- a/service/src/client/data.client.ts
+++ b/service/src/client/data.client.ts
@@ -1,66 +1,104 @@
+import { logger } from '../utils/logger.utils';
 import { createApiRoot } from './create.client';
 
 export const getData = async (container: string) => {
-  const data = await createApiRoot()
-    .customObjects()
-    .withContainer({ container: container })
-    .get()
-    .execute();
-  return data?.body?.results
-    ?.map((x) => ({ [x.key]: x.value }))
-    ?.reduce((acc, curr) => Object.assign(acc, curr), {});
+  try {
+    return (
+      await createApiRoot()
+        .customObjects()
+        .withContainer({ container: container })
+        .get()
+        .execute()
+    )?.body?.results
+      ?.map((x) => ({ [x.key]: x.value }))
+      ?.reduce((acc, curr) => Object.assign(acc, curr), {});
+  } catch (e) {
+    logger.error(e);
+    return {};
+  }
 };
 
 export const getShipTaxCode = async (id: string) => {
-  return (
-    await createApiRoot().shippingMethods().withId({ ID: id }).get().execute()
-  )?.body?.custom?.fields?.avalaraTaxCode as string;
+  try {
+    return (
+      await createApiRoot().shippingMethods().withId({ ID: id }).get().execute()
+    )?.body?.custom?.fields?.avalaraTaxCode as string;
+  } catch (e) {
+    logger.error(e);
+    return '';
+  }
 };
 
 export const getCustomerEntityUseCode = async (id: string) => {
-  return (await createApiRoot().customers().withId({ ID: id }).get().execute())
-    ?.body?.custom?.fields?.avalaraEntityUseCode as string;
+  try {
+    return (
+      await createApiRoot().customers().withId({ ID: id }).get().execute()
+    )?.body?.custom?.fields?.avalaraEntityUseCode as string;
+  } catch (e) {
+    logger.error(e);
+    return '';
+  }
 };
 
-export const getBulkCategoryTaxCode = async (cats: Array<string>) => {
-  const cs = cats
-    .map((x) => `"${x}", `)
-    .reduce((acc, curr) => acc + curr, '')
-    .slice(0, -2);
-  const taxCodes = (
-    await createApiRoot()
-      .categories()
-      .get({ queryArgs: { where: `id in (${cs})`, limit: 500 } })
-      .execute()
-  )?.body?.results?.map((x) => ({
-    id: x.id,
-    avalaraTaxCode: x.custom?.fields?.avalaraTaxCode,
-  }));
-  return taxCodes;
+export const getBulkCategoryTaxCode = async (categories: Array<string>) => {
+  if (!categories.length) return [];
+  try {
+    return (
+      await createApiRoot()
+        .categories()
+        .get({
+          queryArgs: {
+            where: `id in (${categories
+              .map((x) => `"${x}", `)
+              .reduce((acc, curr) => acc + curr, '')
+              .slice(0, -2)})`,
+            limit: 500,
+          },
+        })
+        .execute()
+    )?.body?.results?.map((x) => ({
+      id: x.id,
+      avalaraTaxCode: x.custom?.fields?.avalaraTaxCode as string,
+    }));
+  } catch (e) {
+    logger.error(e);
+    return [];
+  }
 };
 
 export const getBulkProductCategories = async (
   keys: Array<string | undefined>
 ) => {
-  const ps = keys
-    .map((x) => `"${x}",`)
-    .reduce((acc, curr) => acc + curr, 'variants.sku:')
-    .slice(0, -1);
-  const data = (
-    await createApiRoot()
-      .productProjections()
-      .search()
-      .get({ queryArgs: { filter: ps, limit: 500 } })
-      .execute()
-  )?.body?.results;
-  const result: any = keys.map((x) => ({
-    sku: x,
-    categories: data
-      ?.find(
-        (y) =>
-          y?.masterVariant?.sku === x || y?.variants?.find((z) => z?.sku === x)
-      )
-      ?.categories?.map((x: any) => x.id),
-  }));
-  return result;
+  try {
+    const data = (
+      await createApiRoot()
+        .productProjections()
+        .search()
+        .get({
+          queryArgs: {
+            filter: keys
+              .map((x) => `"${x}",`)
+              .reduce((acc, curr) => acc + curr, 'variants.sku:')
+              .slice(0, -1) as string,
+            limit: 500,
+          },
+        })
+        .execute()
+    )?.body?.results;
+    return keys
+      .map((x) => ({
+        sku: x as string,
+        categories: data
+          ?.find(
+            (y) =>
+              y?.masterVariant?.sku === x ||
+              y?.variants?.find((z) => z?.sku === x)
+          )
+          ?.categories?.map((x: any) => x.id) as string[],
+      }))
+      .filter((x) => x.categories && x.categories.length > 0);
+  } catch (e) {
+    logger.error(e);
+    return [];
+  }
 };

--- a/service/src/controllers/check.address.controller.ts
+++ b/service/src/controllers/check.address.controller.ts
@@ -33,7 +33,7 @@ export const checkAddressController = async (data: {
     throw new CustomError(400, 'Bad request: Missing address');
   }
   const settings = await getData('avalara-connector-settings').then(
-    (res) => res.settings
+    (res) => res?.settings
   );
   if (!data?.mcApp && !settings?.addressValidation) {
     return {

--- a/service/tests/client.spec.ts
+++ b/service/tests/client.spec.ts
@@ -57,7 +57,7 @@ describe('test coco api client', () => {
     const data = await getData('avalara-connector-settings');
     expect(apiRoot.execute).toBeCalledTimes(1);
     expect(apiRoot.execute).toThrowError();
-    expect(data).toEqual({});
+    expect(data).toBeUndefined();
   });
 
   test('get shipping tax code method', async () => {
@@ -79,7 +79,7 @@ describe('test coco api client', () => {
     expect(apiRoot.execute).toBeCalledTimes(1);
     expect(apiRoot.execute).toThrowError();
 
-    expect(data).toEqual('');
+    expect(data).toBeUndefined();
   });
 
   test('get customer entity use code method', async () => {
@@ -101,7 +101,7 @@ describe('test coco api client', () => {
     expect(apiRoot.execute).toBeCalledTimes(1);
     expect(apiRoot.execute).toThrowError();
 
-    expect(data).toEqual('');
+    expect(data).toBeUndefined();
   });
 
   test('get all categories of a list of products', async () => {

--- a/service/tests/client.spec.ts
+++ b/service/tests/client.spec.ts
@@ -55,14 +55,8 @@ describe('test coco api client', () => {
       throw new Error('error');
     });
     const data = await getData('avalara-connector-settings');
-    expect(apiRoot.customObjects).toBeCalledTimes(1);
-    expect(apiRoot.withContainer).toBeCalledWith({
-      container: 'avalara-connector-settings',
-    });
-    expect(apiRoot.get).toBeCalledTimes(1);
     expect(apiRoot.execute).toBeCalledTimes(1);
     expect(apiRoot.execute).toThrowError();
-
     expect(data).toEqual({});
   });
 
@@ -82,9 +76,6 @@ describe('test coco api client', () => {
       throw new Error('error');
     });
     const data = await getShipTaxCode('123');
-    expect(apiRoot.shippingMethods).toBeCalledTimes(1);
-    expect(apiRoot.withId).toBeCalledWith({ ID: '123' });
-    expect(apiRoot.get).toBeCalledTimes(1);
     expect(apiRoot.execute).toBeCalledTimes(1);
     expect(apiRoot.execute).toThrowError();
 
@@ -107,9 +98,6 @@ describe('test coco api client', () => {
       throw new Error('error');
     });
     const data = await getCustomerEntityUseCode('123');
-    expect(apiRoot.customers).toBeCalledTimes(1);
-    expect(apiRoot.withId).toBeCalledWith({ ID: '123' });
-    expect(apiRoot.get).toBeCalledTimes(1);
     expect(apiRoot.execute).toBeCalledTimes(1);
     expect(apiRoot.execute).toThrowError();
 
@@ -138,11 +126,6 @@ describe('test coco api client', () => {
       throw new Error('error');
     });
     const data = await getBulkProductCategories(['sku123', 'sku456']);
-    expect(apiRoot.productProjections).toBeCalledTimes(1);
-    expect(apiRoot.search).toBeCalledTimes(1);
-    expect(apiRoot.get).toBeCalledWith({
-      queryArgs: { filter: `variants.sku:"sku123","sku456"`, limit: 500 },
-    });
     expect(apiRoot.execute).toBeCalledTimes(1);
     expect(apiRoot.execute).toThrowError();
 
@@ -170,10 +153,6 @@ describe('test coco api client', () => {
       throw new Error('error');
     });
     const data = await getBulkCategoryTaxCode(['123', '456']);
-    expect(apiRoot.categories).toBeCalledTimes(1);
-    expect(apiRoot.get).toBeCalledWith({
-      queryArgs: { where: `id in ("123", "456")`, limit: 500 },
-    });
     expect(apiRoot.execute).toBeCalledTimes(1);
     expect(apiRoot.execute).toThrowError();
 

--- a/service/tests/client.spec.ts
+++ b/service/tests/client.spec.ts
@@ -60,7 +60,7 @@ describe('test coco api client', () => {
     expect(data).toBeUndefined();
   });
 
-  test('get shipping tax code method', async () => {
+  test('get shipping tax code method succeeds', async () => {
     apiRoot.execute = jest.fn(() => shipTaxCodeBody);
     const data = await getShipTaxCode('123');
     expect(apiRoot.shippingMethods).toBeCalledTimes(1);
@@ -82,7 +82,7 @@ describe('test coco api client', () => {
     expect(data).toBeUndefined();
   });
 
-  test('get customer entity use code method', async () => {
+  test('get customer entity use code method succeeds', async () => {
     apiRoot.execute = jest.fn(() => entityUseCodeBody);
     const data = await getCustomerEntityUseCode('123');
     expect(apiRoot.customers).toBeCalledTimes(1);
@@ -104,7 +104,7 @@ describe('test coco api client', () => {
     expect(data).toBeUndefined();
   });
 
-  test('get all categories of a list of products', async () => {
+  test('get all categories of a list of products succeeds', async () => {
     apiRoot.execute = jest.fn(() => bulkProductCategoriesBody);
     const data = await getBulkProductCategories(['sku123', 'sku456']);
     expect(apiRoot.productProjections).toBeCalledTimes(1);
@@ -132,7 +132,7 @@ describe('test coco api client', () => {
     expect(data).toEqual([]);
   });
 
-  test('get all tax codes of a list of categories', async () => {
+  test('get all tax codes of a list of categories succeeds', async () => {
     apiRoot.execute = jest.fn(() => bulkCategoryTaxCodeBody);
     const data = await getBulkCategoryTaxCode(['123', '456']);
     expect(apiRoot.categories).toBeCalledTimes(1);

--- a/service/tests/client.spec.ts
+++ b/service/tests/client.spec.ts
@@ -36,7 +36,7 @@ describe('test coco api client', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
-  test('get avalara merchant data method', async () => {
+  test('get avalara merchant data method succeeds', async () => {
     apiRoot.execute = jest.fn(() => avalaraMerchantDataBody);
     const data = await getData('avalara-connector-settings');
     expect(apiRoot.customObjects).toBeCalledTimes(1);
@@ -50,6 +50,22 @@ describe('test coco api client', () => {
     expect(Object.keys(data?.settings).length).toBe(12);
   });
 
+  test('get avalara merchant data method fails', async () => {
+    apiRoot.execute = jest.fn(() => {
+      throw new Error('error');
+    });
+    const data = await getData('avalara-connector-settings');
+    expect(apiRoot.customObjects).toBeCalledTimes(1);
+    expect(apiRoot.withContainer).toBeCalledWith({
+      container: 'avalara-connector-settings',
+    });
+    expect(apiRoot.get).toBeCalledTimes(1);
+    expect(apiRoot.execute).toBeCalledTimes(1);
+    expect(apiRoot.execute).toThrowError();
+
+    expect(data).toEqual({});
+  });
+
   test('get shipping tax code method', async () => {
     apiRoot.execute = jest.fn(() => shipTaxCodeBody);
     const data = await getShipTaxCode('123');
@@ -61,6 +77,20 @@ describe('test coco api client', () => {
     expect(data).toBe('PC030000');
   });
 
+  test('get shipping tax code method fails', async () => {
+    apiRoot.execute = jest.fn(() => {
+      throw new Error('error');
+    });
+    const data = await getShipTaxCode('123');
+    expect(apiRoot.shippingMethods).toBeCalledTimes(1);
+    expect(apiRoot.withId).toBeCalledWith({ ID: '123' });
+    expect(apiRoot.get).toBeCalledTimes(1);
+    expect(apiRoot.execute).toBeCalledTimes(1);
+    expect(apiRoot.execute).toThrowError();
+
+    expect(data).toEqual('');
+  });
+
   test('get customer entity use code method', async () => {
     apiRoot.execute = jest.fn(() => entityUseCodeBody);
     const data = await getCustomerEntityUseCode('123');
@@ -70,6 +100,20 @@ describe('test coco api client', () => {
     expect(apiRoot.execute).toBeCalledTimes(1);
 
     expect(data).toBe('B');
+  });
+
+  test('get customer entity use code method fails', async () => {
+    apiRoot.execute = jest.fn(() => {
+      throw new Error('error');
+    });
+    const data = await getCustomerEntityUseCode('123');
+    expect(apiRoot.customers).toBeCalledTimes(1);
+    expect(apiRoot.withId).toBeCalledWith({ ID: '123' });
+    expect(apiRoot.get).toBeCalledTimes(1);
+    expect(apiRoot.execute).toBeCalledTimes(1);
+    expect(apiRoot.execute).toThrowError();
+
+    expect(data).toEqual('');
   });
 
   test('get all categories of a list of products', async () => {
@@ -89,6 +133,22 @@ describe('test coco api client', () => {
     expect(data[1]?.categories[0]).toBe('456');
   });
 
+  test('get all categories of a list of products fails', async () => {
+    apiRoot.execute = jest.fn(() => {
+      throw new Error('error');
+    });
+    const data = await getBulkProductCategories(['sku123', 'sku456']);
+    expect(apiRoot.productProjections).toBeCalledTimes(1);
+    expect(apiRoot.search).toBeCalledTimes(1);
+    expect(apiRoot.get).toBeCalledWith({
+      queryArgs: { filter: `variants.sku:"sku123","sku456"`, limit: 500 },
+    });
+    expect(apiRoot.execute).toBeCalledTimes(1);
+    expect(apiRoot.execute).toThrowError();
+
+    expect(data).toEqual([]);
+  });
+
   test('get all tax codes of a list of categories', async () => {
     apiRoot.execute = jest.fn(() => bulkCategoryTaxCodeBody);
     const data = await getBulkCategoryTaxCode(['123', '456']);
@@ -103,5 +163,20 @@ describe('test coco api client', () => {
     expect(data[0]?.avalaraTaxCode).toBe('PS081282');
     expect(data[1]?.id).toBe('456');
     expect(data[1]?.avalaraTaxCode).toBe('PS080101');
+  });
+
+  test('get all tax codes of a list of categories fails', async () => {
+    apiRoot.execute = jest.fn(() => {
+      throw new Error('error');
+    });
+    const data = await getBulkCategoryTaxCode(['123', '456']);
+    expect(apiRoot.categories).toBeCalledTimes(1);
+    expect(apiRoot.get).toBeCalledWith({
+      queryArgs: { where: `id in ("123", "456")`, limit: 500 },
+    });
+    expect(apiRoot.execute).toBeCalledTimes(1);
+    expect(apiRoot.execute).toThrowError();
+
+    expect(data).toEqual([]);
   });
 });


### PR DESCRIPTION
Made changes for the following use case: 
1) A customer has some products in the cart. 
2) The commercetools merchant unpublishes one of the products that are in the cart. 
3) In this case, this product becomes unavailable under the "product projections search" commercetools endpoint, which is used to fetch the categories of all products.
4) The categories are then queried for the tax code custom field values. 
5) If a product was unavailable under product projections, it would return undefined categories. 
6) When fetching the categories tax codes, the method for the fetch would raise an error for the undefined categories. 

Note: it seems weird that the unpublished products still remain in the cart. However, this is a confirmed behavior of the commercetools API and the merchant has to take care of the products removal himself, as stated here: https://docs.commercetools.com/api/carts-orders-overview#cart-updates. Still, as it can vary at which point the merchant would do that, the present connector behaviour needed to be mended.
The changes (once for service and once for event):
- filter out the undefined categories when querying categories for the tax codes. (this will lead the unpublished product tax code to be undefined <=> set to the default Avalara tax code.)
- early return empty values for empty arguments.
- catch and log all errors in the commercetools API client and return undefined/empty values in case of errors. 
- refactor the "getCategoryTaxCodes" method according to these changes. 
- update the integration tests according to these changes.
